### PR TITLE
Handle singular and plural forms

### DIFF
--- a/src/Model/Action/QueryAction.php
+++ b/src/Model/Action/QueryAction.php
@@ -44,27 +44,18 @@ class QueryAction extends BaseAction
     {
         $data = array_merge(['query' => null, 'variables' => null, 'operationName' => null], $data);
 
-        try {
-            $this->buildSchema();
+        $this->buildSchema();
 
-            $result = GraphQL::executeQuery(
-                $this->schema,
-                $data['query'],
-                null,
-                new AppContext(),
-                $data['variables'],
-                $data['operationName']
-            );
+        $result = GraphQL::executeQuery(
+            $this->schema,
+            $data['query'],
+            null,
+            new AppContext(),
+            $data['variables'],
+            $data['operationName']
+        );
 
-            $result = $result->toArray();
-        } catch (\Exception $e) {
-            $result = [
-                'errors' => [
-                    'message' => $e->getMessage()
-                ],
-                'status' => 500,
-            ];
-        }
+        $result = $result->toArray();
 
         return $result;
     }

--- a/tests/TestCase/Controller/GraphQLControllerTest.php
+++ b/tests/TestCase/Controller/GraphQLControllerTest.php
@@ -38,7 +38,7 @@ class GraphQLControllerTest extends IntegrationTestCase
             'application json' => [
                  'application/json',
                  'POST',
-                 '{"query": "query { users(id: \"1\") { username }}"}',
+                 '{"query": "query { user(id: \"1\") { username }}"}',
             ],
             // TODO: works from -  curl -H Content-Type:application/graphql http://be4.dev/graphql -d "query{users(id:\"1\"){username}}"
             // but not on on unit tests, why??
@@ -50,13 +50,13 @@ class GraphQLControllerTest extends IntegrationTestCase
             'no type' => [
                 '',
                 'POST',
-                '{"query": "{ users(id: \"1\") { username }}"}'
+                '{"query": "{ user(id: \"1\") { username }}"}'
             ],
             'simple get' => [
                 '',
                 'GET',
                 '',
-                'query={users(id:"1"){username}}'
+                'query={user(id:"1"){username}}'
             ],
         ];
     }
@@ -75,7 +75,7 @@ class GraphQLControllerTest extends IntegrationTestCase
     {
         $expected = [
             'data' => [
-                'users' => [
+                'user' => [
                     'username' => 'first user',
                 ]
             ]

--- a/tests/TestCase/Model/Action/QueryActionTest.php
+++ b/tests/TestCase/Model/Action/QueryActionTest.php
@@ -16,6 +16,7 @@ namespace BEdita\GraphQL\Test\TestCase\Model\Action;
 use BEdita\GraphQL\Model\Action\QueryAction;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+//use GraphQL\Type\Schema;
 
 /**
  * {@see \BEdita\GraphQL\Model\Action\QueryAction} Test Case
@@ -50,16 +51,19 @@ class QueryActionTest extends TestCase
      *
      * @covers ::execute()
      * @covers ::buildSchema()
+     * @covers \BEdita\GraphQL\Model\Type\ObjectsType::__construct()
+     * @covers \BEdita\GraphQL\Model\Type\QueryType::__construct()
+     * @covers \BEdita\GraphQL\Model\Type\ResourcesType::__construct()
      */
     public function testExecute()
     {
-        $query = '{users(id: "1") { username }}';
+        $query = '{user(id: "1") { username }}';
         $action = new QueryAction();
         $result = $action(compact('query'));
 
         $expected = [
             'data' => [
-                'users' => [
+                'user' => [
                     'username' => 'first user',
                 ]
             ]
@@ -69,13 +73,13 @@ class QueryActionTest extends TestCase
         static::assertArrayNotHasKey('errors', $result);
         static::assertEquals($expected, $result);
 
-        $query = '{roles(id: "1") { name }}';
+        $query = '{role(id: "1") { name }}';
         $action = new QueryAction();
         $result = $action(compact('query'));
 
         $expected = [
             'data' => [
-                'roles' => [
+                'role' => [
                     'name' => 'first role',
                 ]
             ]

--- a/tests/TestCase/Model/Action/QueryActionTest.php
+++ b/tests/TestCase/Model/Action/QueryActionTest.php
@@ -16,7 +16,6 @@ namespace BEdita\GraphQL\Test\TestCase\Model\Action;
 use BEdita\GraphQL\Model\Action\QueryAction;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-//use GraphQL\Type\Schema;
 
 /**
  * {@see \BEdita\GraphQL\Model\Action\QueryAction} Test Case

--- a/tests/TestCase/Model/TypesRegistryTest.php
+++ b/tests/TestCase/Model/TypesRegistryTest.php
@@ -61,14 +61,27 @@ class TypesRegistryTest extends TestCase
         $result = TypesRegistry::rootTypes();
 
         $expected = [
+            'application',
             'applications',
+            'document',
             'documents',
+            'event',
             'events',
+            'file',
+            'files',
+            'location',
             'locations',
             'media',
+            'media_item',
             'news',
+            'news_item',
+            'object',
+            'objects',
+            'profile',
             'profiles',
+            'role',
             'roles',
+            'user',
             'users',
         ];
 
@@ -83,18 +96,49 @@ class TypesRegistryTest extends TestCase
     }
 
     /**
-     * Test `isAnObject` method
+     * Data provider for `testInspectTypeName`
      *
+     * @return array
+     */
+    public function inspectProvider()
+    {
+        return [
+            'user' => [
+                'user',
+                TypesRegistry::SINGLE_OBJECT,
+            ],
+            'users' => [
+                'users',
+                TypesRegistry::OBJECTS_LIST,
+            ],
+            'role' => [
+                'role',
+                TypesRegistry::SINGLE_RESOURCE,
+            ],
+            'roles' => [
+                'roles',
+                TypesRegistry::RESOURCES_LIST,
+            ],
+            'guatavo' => [
+                'gustavo',
+                false,
+            ],
+         ];
+    }
+
+    /**
+     * Test `inspectTypeName` method
+     *
+     * @param string $name Type name
+     * @param mixed $expected Inspection result
      * @return void
      *
-     * @covers ::isAnObject()
+     * @dataProvider inspectProvider
+     * @covers ::inspectTypeName()
      */
-    public function testIsAnObject()
+    public function testInspectTypeName($name, $expected)
     {
-        $result = TypesRegistry::isAnObject('documents');
-        static::assertTrue($result);
-
-        $result = TypesRegistry::isAnObject('roles');
-        static::assertFalse($result);
+        $result = TypesRegistry::inspectTypeName($name);
+        static::assertEquals($result, $expected);
     }
 }


### PR DESCRIPTION
With this PR singular and plural query are supported.

This means that possible queries now are:

- **singular**
```graphql
{
  role(id: 1) {
    description
  }
}
```
- **plural**
```graphql
{
  roles {
    name
  }
}
```