### PR TITLE
Add core property types

### DIFF
--- a/src/Model/FieldsRegistry.php
+++ b/src/Model/FieldsRegistry.php
@@ -76,7 +76,7 @@ class FieldsRegistry
             $fields = [];
             $properties = static::objectProperties($name);
             foreach ($properties as $prop) {
-                $fields[$prop->get('name')] = TypesRegistry::string();
+                $fields[$prop->get('name')] = TypesRegistry::fromPropertySchema($prop->getSchema());
             }
             self::$objectFields[$name] = $fields;
         }

--- a/src/Model/Type/DateTimeType.php
+++ b/src/Model/Type/DateTimeType.php
@@ -50,12 +50,11 @@ class DateTimeType extends ScalarType
             throw new InvariantViolation("DateTime can represent only strings or integer values: " . Utils::printSafe($value));
         }
 
-        return (string) $value;
+        return (string)$value;
     }
 
     /**
-     * @param mixed $value
-     * @return string
+     * {@inheritDoc}
      * @codeCoverageIgnore
      */
     public function parseValue($value)
@@ -64,8 +63,7 @@ class DateTimeType extends ScalarType
     }
 
     /**
-     * @param mixed $ast AST input
-     * @return null|string
+     * {@inheritDoc}
      */
     public function parseLiteral($ast)
     {

--- a/src/Model/Type/DateTimeType.php
+++ b/src/Model/Type/DateTimeType.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\GraphQL\Model\Type;
+
+use Cake\I18n\Time;
+use GraphQL\Error\Error;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\AST\StringValueNode;
+use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Utils\Utils;
+
+/**
+ * Internal DateTime Type
+ */
+class DateTimeType extends ScalarType
+{
+    /**
+     * @var string
+     */
+    public $name = 'DateTime';
+
+    /**
+     * @var string
+     */
+    public $description = 'The `DateTime` scalar type represents a datetime, represented as ISO 8601 string';
+
+    /**
+     * Serialize input value to date time string
+
+     * @param mixed $value Input data to serialize, must be Time or string
+     * @return null|string
+     */
+    public function serialize($value)
+    {
+        if ($value instanceof Time) {
+            return $value->jsonSerialize();
+        }
+        if (!is_string($value)) {
+            throw new InvariantViolation("DateTime can represent only strings or integer values: " . Utils::printSafe($value));
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     * @codeCoverageIgnore
+     */
+    public function parseValue($value)
+    {
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * @param mixed $ast AST input
+     * @return null|string
+     */
+    public function parseLiteral($ast)
+    {
+        if ($ast instanceof StringValueNode) {
+            return $ast->value;
+        }
+
+        return null;
+    }
+}

--- a/tests/TestCase/Model/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Model/Type/DateTimeTypeTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+
+namespace BEdita\GraphQL\Test\TestCase\Model\Type;
+
+use BEdita\GraphQL\Model\Type\DateTimeType;
+use Cake\I18n\Time;
+use Cake\TestSuite\TestCase;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\AST\StringValueNode;
+
+/**
+ * {@see \BEdita\GraphQL\Model\Type\DateTimeType} Test Case
+ *
+ * @coversDefaultClass \BEdita\GraphQL\Model\Type\DateTimeType
+ */
+class DateTimeTypeTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \BEdita\GraphQL\Model\Type\DateTimeType
+     */
+    public $dateTimeType;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->dateTimeType = new DateTimeType();
+    }
+
+    /**
+     * Data provider for `testSerialiaze`
+     *
+     * @return void
+     */
+    public function serialiazeProvider()
+    {
+        return [
+            'time' => [
+                Time::parse('2018-01-07 12:40:19'),
+                '2018-01-07T12:40:19+00:00',
+            ],
+            'string' => [
+                '2018-01-07T12:40:19+00:00',
+                '2018-01-07T12:40:19+00:00',
+            ],
+            'bad' => [
+                123456789,
+                new InvariantViolation('DateTime can represent only strings or integer values: 123456789'),
+            ],
+        ];
+    }
+
+    /**
+     * Test `serialize` method
+     *
+     * @return void
+     *
+     * @covers ::serialize()
+     * @dataProvider serialiazeProvider
+     */
+    public function testSerialiaze($input, $expected)
+    {
+        if ($expected instanceof \Exception) {
+            $this->expectException(get_class($expected));
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+        $result = $this->dateTimeType->serialize($input);
+        static::assertEquals($result, $expected);
+    }
+
+    /**
+     * Test `parseValue` method
+     *
+     * @return void
+     *
+     * @covers ::parseLiteral()
+     */
+    public function testParseLiteral()
+    {
+        $date = '2018-01-01';
+        $ast = new StringValueNode([]);
+        $ast->value = $date;
+        $result = $this->dateTimeType->parseLiteral($ast);
+        static::assertEquals($result, $date);
+
+        $result = $this->dateTimeType->parseLiteral($date);
+        static::assertNull($result);
+    }
+}

--- a/tests/TestCase/Model/Type/ResourcesTypeTest.php
+++ b/tests/TestCase/Model/Type/ResourcesTypeTest.php
@@ -31,6 +31,7 @@ class ResourcesTypeTest extends TestCase
      */
     public $fixtures = [
         'plugin.BEdita/Core.property_types',
+        'plugin.BEdita/Core.object_types',
         'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.applications',

--- a/tests/TestCase/Model/Type/ResourcesTypeTest.php
+++ b/tests/TestCase/Model/Type/ResourcesTypeTest.php
@@ -30,6 +30,8 @@ class ResourcesTypeTest extends TestCase
      * @var array
      */
     public $fixtures = [
+        'plugin.BEdita/Core.property_types',
+        'plugin.BEdita/Core.properties',
         'plugin.BEdita/Core.roles',
         'plugin.BEdita/Core.applications',
     ];

--- a/tests/TestCase/Model/TypesRegistryTest.php
+++ b/tests/TestCase/Model/TypesRegistryTest.php
@@ -141,4 +141,90 @@ class TypesRegistryTest extends TestCase
         $result = TypesRegistry::inspectTypeName($name);
         static::assertEquals($result, $expected);
     }
+
+    /**
+     * Data provider for `testPropertySchema`
+     *
+     * @return void
+     */
+    public function propertySchemaProvider()
+    {
+        return [
+            'date' => [
+                [
+                    'type' => 'string',
+                    'format' => 'date-time',
+                ],
+                TypesRegistry::dateTime(),
+            ],
+            'int' => [
+                [
+                    'oneOf' => [
+                        [
+                            'type' => 'null',
+                        ],
+                        [
+                            'type' => 'integer',
+                        ]
+                    ],
+                ],
+                TypesRegistry::int(),
+            ],
+            'bool' => [
+                [
+                    'oneOf' => [
+                        [
+                            'type' => 'boolean',
+                        ],
+                        [
+                            'type' => 'null',
+                        ]
+                    ],
+                ],
+                TypesRegistry::boolean(),
+            ],
+            'float' => [
+                [
+                    'type' => 'number',
+                ],
+                TypesRegistry::float(),
+            ],
+            'text' => [
+                [
+                    'type' => 'string',
+                    'contentMediaType' => 'text/html',
+                ],
+                TypesRegistry::string(),
+            ],
+            'unknown' => [
+                [
+                    'type' => 'sometype',
+                ],
+                TypesRegistry::string(),
+            ],
+            'moreunknown' => [
+                [
+                    'unknown' => 'weirdtype',
+                ],
+                TypesRegistry::string(),
+            ],
+        ];
+    }
+
+    /**
+     * Test `fromPropertySchema` method
+     *
+     * @return void
+     *
+     * @param array $schema Property JSON schema
+     * @param mixed $expected Expected property type
+     * @covers ::fromPropertySchema()
+     * @covers ::propertyFromTypeSchema()
+     * @dataProvider propertySchemaProvider
+     */
+    public function testPropertySchema(array $schema, $expected)
+    {
+        $result = TypesRegistry::fromPropertySchema($schema);
+        static::assertEquals($result, $expected);
+    }
 }


### PR DESCRIPTION

 * actual property types are used, available after bedita/bedita#1379 
 * custom `DateTimeType` introduced since its not available in graphql library, will be improved later
 * if no match is found for a property type is found `TypeRegistry::string()` is used
